### PR TITLE
fixed typo in get_account() examples

### DIFF
--- a/R/get_account.R
+++ b/R/get_account.R
@@ -7,7 +7,7 @@
 #' @examples
 #' \dontrun{
 #' # account details
-#' get_aaccount()
+#' get_account()
 #' 
 #' # big list of authorizations
 #' auth_details()

--- a/man/get_account.Rd
+++ b/man/get_account.Rd
@@ -33,7 +33,7 @@ Retrieve IAM Account Details. This is useful as a \dQuote{hello world!} test.
 \examples{
 \dontrun{
 # account details
-get_aaccount()
+get_account()
 
 # big list of authorizations
 auth_details()


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/cloudyr/aws.iam/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/cloudyr/aws.iam/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/cloudyr/aws.iam/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [ ] add code or new test files to [`/tests`](https://github.com/cloudyr/aws.iam/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR
 
`R CMD check` has one warning unrelated to this documentation:

`aws.s3` is called in the tests at https://github.com/cloudyr/aws.iam/blob/master/tests/test.R#L49 and `R CMD check` warns that it's not listed in imports/depends/suggests. This can be resolved by adding `Suggests: aws.s3` which I can do in a separate PR so as not to confuse the two fixes.

